### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - '8'
+  - '10'
+  - 'node'
 
 env:
   global:
@@ -16,6 +18,8 @@ addons:
 script:
   - npm test
   - npm run lint
+
+install: npm install
 
 after_success:
   - npm run test:coveralls


### PR DESCRIPTION
We should test LTS 8 and 10 and current stable (11).
Also `npm install` should be used as lockfiles are ignored in published packages.