### PR TITLE
Added safe check for avoiding type errors in case of empty schemas.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,6 +40,11 @@ const helpers = {
   mergeSchemaObjs(schema1, schema2) {
     const schema1Keys = keys(schema1)
     const schema2Keys = keys(schema2)
+
+    if (!schema1 || !schema2) {
+      return null;
+    }
+
     if (!isEqual(schema1Keys, schema2Keys)) {
       if (schema1.type === 'array' && schema2.type === 'array') {
         // TODO optimize???


### PR DESCRIPTION
While using this module for transforming to schema from certain JSON data, I was getting `TypeError: Cannot read property 'type' of null` due to the schema being `null` in some cases.

This PR adds a safe check before proceeding further that schemas are not empty (null/undefined).